### PR TITLE
修复安卓15中不能使用已安装的webview的问题（仅测试安卓15虚拟机和安卓15小米）

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -3,6 +3,13 @@
 
     <queries>
         <package android:name="com.android.chrome" />
+        <package android:name="com.android.webview" />
+        <package android:name="com.google.android.webview" />
+        <package android:name="com.google.android.webview.beta" />
+        <package android:name="com.google.android.webview.canary" />
+        <package android:name="com.google.android.webview.dev" />
+        <package android:name="com.huawei.webview" />
+        <package android:name="org.bromite.webview" />
     </queries>
 
     <application

--- a/app/src/main/java/cn/hle/skipselfstartmanager/util/MobileInfoUtils.java
+++ b/app/src/main/java/cn/hle/skipselfstartmanager/util/MobileInfoUtils.java
@@ -1,0 +1,74 @@
+package cn.hle.skipselfstartmanager.util;
+
+import android.content.ComponentName;
+import android.content.Context;
+import android.content.Intent;
+import android.net.Uri;
+import android.os.Build;
+import android.provider.Settings;
+import android.util.Log;
+
+/**
+ * Mobile Info Utils
+ * create by heliquan at 2017年3月23日
+ */
+public class MobileInfoUtils {
+
+    /**
+     * Get Mobile Type
+     *
+     * @return
+     */
+    private static String getMobileType() {
+        return Build.MANUFACTURER;
+    }
+
+    /**
+     * GoTo Open Self Setting Layout
+     * Compatible Mainstream Models 兼容市面主流机型
+     * adb shell dumpsys activity top
+     *
+     * @param context
+     */
+    public static void jumpStartInterface(Context context) {
+        Intent intent = new Intent();
+        try {
+            intent.addFlags(Intent.FLAG_ACTIVITY_NEW_TASK);
+            Log.e("HLQ_Struggle", "******************当前手机型号为：" + getMobileType());
+            ComponentName componentName = null;
+            if (getMobileType().equals("Xiaomi")) { // 红米Note4测试通过
+                componentName = new ComponentName("com.miui.securitycenter", "com.miui.permcenter.autostart.AutoStartManagementActivity");
+            } else if (getMobileType().equals("Letv")) { // 乐视2测试通过
+                intent.setAction("com.letv.android.permissionautoboot");
+            } else if (getMobileType().equals("samsung")) { // 三星Note5测试通过
+                componentName = new ComponentName("com.samsung.android.sm_cn", "com.samsung.android.sm.ui.ram.AutoRunActivity");
+            } else if (getMobileType().equals("HUAWEI")) { // 华为测试通过
+                componentName = new ComponentName("com.huawei.systemmanager", "com.huawei.systemmanager.optimize.process.ProtectActivity");
+            } else if (getMobileType().equals("vivo")) { // VIVO测试通过
+                componentName = ComponentName.unflattenFromString("com.iqoo.secure/.safeguard.PurviewTabActivity");
+            } else if (getMobileType().equals("Meizu")) { //万恶的魅族
+                componentName = ComponentName.unflattenFromString("com.meizu.safe/.permission.PermissionMainActivity");
+            } else if (getMobileType().equals("OPPO")) { // OPPO R8205测试通过
+                componentName = ComponentName.unflattenFromString("com.oppo.safe/.permission.startup.StartupAppListActivity");
+            } else if (getMobileType().equals("ulong")) { // 360手机 未测试
+                componentName = new ComponentName("com.yulong.android.coolsafe", ".ui.activity.autorun.AutoRunListActivity");
+            } else {
+                // 将用户引导到系统设置页面
+                if (Build.VERSION.SDK_INT >= 9) {
+                    intent.setAction("android.settings.APPLICATION_DETAILS_SETTINGS");
+                    intent.setData(Uri.fromParts("package", context.getPackageName(), null));
+                } else if (Build.VERSION.SDK_INT <= 8) {
+                    intent.setAction(Intent.ACTION_VIEW);
+                    intent.setClassName("com.android.settings", "com.android.settings.InstalledAppDetails");
+                    intent.putExtra("com.android.settings.ApplicationPkgName", context.getPackageName());
+                }
+            }
+            intent.setComponent(componentName);
+            context.startActivity(intent);
+        } catch (Exception e) {//抛出异常就直接打开设置页面
+            intent = new Intent(Settings.ACTION_SETTINGS);
+            context.startActivity(intent);
+        }
+    }
+
+}

--- a/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
+++ b/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
@@ -38,6 +38,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
+import cn.hle.skipselfstartmanager.util.MobileInfoUtils;
+
 
 public class MainActivity extends Activity implements UpgradeCallback {
 
@@ -263,16 +265,16 @@ public class MainActivity extends Activity implements UpgradeCallback {
                                 dlg.setMessage("请授予Webview(" + upgradeInfo.packageName + ")自启动权限后重新进入APP，否则本App将无法正常使用Webview组件！");
                                 dlg.setTitle("Alert");
                                 dlg.setCancelable(false);
-                                dlg.setPositiveButton(android.R.string.ok,
-                                        (dialog1, which1) -> {
-                                            navigateToAppSettingsAndExit(upgradeInfo);
-                                        });
+                                dlg.setPositiveButton("立即设置",
+                                        (dialog1, which1) -> navigateToAppSettingsAndExit());
+                                dlg.setNegativeButton("暂时不设置",
+                                        (dialog3, which2) -> dialog3.dismiss());
                                 dlg.setOnKeyListener((dialog2, keyCode, event) -> {
                                     if (keyCode == KeyEvent.KEYCODE_BACK) {
                                         return false;
                                     }
                                     else {
-                                        navigateToAppSettingsAndExit(upgradeInfo);
+                                        navigateToAppSettingsAndExit();
                                         return true;
                                     }
                                 });
@@ -293,12 +295,8 @@ public class MainActivity extends Activity implements UpgradeCallback {
         dialog.show();
     }
 
-    private void navigateToAppSettingsAndExit(UpgradeInfo upgradeInfo) {
-        Intent intent = new Intent();
-        intent.setAction(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
-        Uri uri = Uri.fromParts("package", upgradeInfo.packageName, null);
-        intent.setData(uri);
-        startActivity(intent);
+    private void navigateToAppSettingsAndExit() {
+        MobileInfoUtils.jumpStartInterface(this);
         finish();
         android.os.Process.killProcess(android.os.Process.myPid());
     }

--- a/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
+++ b/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
@@ -1,11 +1,18 @@
 package com.norman.webviewup.demo;
 
 import android.app.Activity;
+import android.content.ComponentName;
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.content.ServiceConnection;
+import android.net.Uri;
+import android.os.Build;
 import android.os.Bundle;
+import android.os.IBinder;
 import android.text.TextUtils;
 import android.util.Log;
+import android.view.KeyEvent;
 import android.view.View;
 import android.webkit.WebView;
 import android.widget.ProgressBar;
@@ -74,8 +81,6 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "122.0.6261.43",
                         "",
                         "安装包")
-
-
         ));
 
         UPGRADE_PACKAGE_MAP.put("arm64", Arrays.asList(
@@ -88,7 +93,13 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "com.huawei.webview",
                         "14.0.0.331",
                         "https://mirror.ghproxy.com/https://raw.githubusercontent.com/JonaNorman/ShareFile/main/com.huawei.webview_14.0.0.331_arm64-v8a_armeabi-v7a.zip",
-                        "网络")
+                        "网络"),
+                //https://mirrors.aliyun.com/android.googlesource.com/external/chromium-webview/prebuilt/arm64/
+                new UpgradeInfo(
+                        "com.android.webview",
+                        "109.0.5414.123",
+                        "",
+                        "安装包")
         ));
 
         UPGRADE_PACKAGE_MAP.put("x86", Arrays.asList(
@@ -107,7 +118,13 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "com.google.android.webview",
                         "131.0.6778.135",
                         "https://www.ghproxy.cn/https://github.com/VoryWork/AndroidWebviewNew/releases/download/131.0.6778.135/x64.apk",
-                        "网络")
+                        "网络"),
+                // https://github.com/bromite/bromite/releases/download/108.0.5359.156/x64_SystemWebView.apk
+                new UpgradeInfo(
+                        "org.bromite.webview",
+                        "108.0.5359.156",
+                        "",
+                        "安装包")
         ));
 
     }
@@ -193,6 +210,9 @@ public class MainActivity extends Activity implements UpgradeCallback {
         for (int i = 0; i < items.length; i++) {
             items[i] = upgradeInfoList.get(i).title;
         }
+
+        Context context = this;
+
         builder.setItems(items, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
@@ -214,6 +234,55 @@ public class MainActivity extends Activity implements UpgradeCallback {
                     if (upgradeSource == null) {
                         return;
                     }
+                    if (Build.VERSION.SDK_INT > 34 && upgradeInfo.extraInfo.equals("安装包")) {
+                        String serviceName =  "org.chromium.content.app.SandboxedProcessService0";
+                        ServiceConnection mConnection = new ServiceConnection() {
+                            @Override
+                            public void onServiceConnected(ComponentName className, IBinder service) {
+                                Log.e("MainActivity", serviceName + "服务连接成功");
+                            }
+
+                            @Override
+                            public void onServiceDisconnected(ComponentName arg0) {
+                                Log.e("MainActivity", serviceName + "服务意外断开");
+                            }
+                        };
+
+                        try {
+                            Intent intent = new Intent();
+                            intent.setClassName(upgradeInfo.packageName, serviceName);
+                            boolean isServiceBound = bindService(intent, mConnection, Context.BIND_AUTO_CREATE);
+
+                            if (isServiceBound) {
+                                // 理论上没有这个情况，因为不可能成功的
+                                Log.e("MainActivity", serviceName + "服务已启动并且绑定成功");
+                            }
+                            else {
+                                Log.e("MainActivity", serviceName + "是服务未启动或不存在");
+                                android.app.AlertDialog.Builder dlg = new android.app.AlertDialog.Builder(context);
+                                dlg.setMessage("请授予Webview(" + upgradeInfo.packageName + ")自启动权限后重新进入APP，否则本App将无法正常使用Webview组件！");
+                                dlg.setTitle("Alert");
+                                dlg.setCancelable(false);
+                                dlg.setPositiveButton(android.R.string.ok,
+                                        (dialog1, which1) -> {
+                                            navigateToAppSettingsAndExit(upgradeInfo);
+                                        });
+                                dlg.setOnKeyListener((dialog2, keyCode, event) -> {
+                                    if (keyCode == KeyEvent.KEYCODE_BACK) {
+                                        return false;
+                                    }
+                                    else {
+                                        navigateToAppSettingsAndExit(upgradeInfo);
+                                        return true;
+                                    }
+                                });
+                                dlg.show();
+                            }
+                        } catch (java.lang.SecurityException e) {
+                            // 有SecurityException就证明webview在后台启动了
+                            Log.e("MainActivity", serviceName + "服务已启动");
+                        }
+                    }
                     WebViewUpgrade.upgrade(upgradeSource);
                     updateUpgradeWebViewPackageInfo();
                     updateUpgradeWebViewStatus();
@@ -222,6 +291,16 @@ public class MainActivity extends Activity implements UpgradeCallback {
         });
         AlertDialog dialog = builder.create();
         dialog.show();
+    }
+
+    private void navigateToAppSettingsAndExit(UpgradeInfo upgradeInfo) {
+        Intent intent = new Intent();
+        intent.setAction(android.provider.Settings.ACTION_APPLICATION_DETAILS_SETTINGS);
+        Uri uri = Uri.fromParts("package", upgradeInfo.packageName, null);
+        intent.setData(uri);
+        startActivity(intent);
+        finish();
+        android.os.Process.killProcess(android.os.Process.myPid());
     }
 
     @Nullable

--- a/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
+++ b/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
@@ -126,7 +126,12 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "org.bromite.webview",
                         "108.0.5359.156",
                         "",
-                        "安装包")
+                        "安装包"),
+                new UpgradeInfo(
+                        "com.android.webview",
+                        "109.5.5414.123",
+                        "webview-x86.apk",
+                        "内置")
         ));
 
     }

--- a/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
+++ b/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
@@ -6,7 +6,6 @@ import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.ServiceConnection;
-import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.IBinder;
@@ -14,7 +13,6 @@ import android.text.TextUtils;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
-import android.webkit.WebView;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -30,7 +28,6 @@ import com.norman.webviewup.lib.source.UpgradePackageSource;
 import com.norman.webviewup.lib.source.UpgradeSource;
 import com.norman.webviewup.lib.source.download.UpgradeDownloadSource;
 import com.norman.webviewup.lib.util.ProcessUtils;
-import com.norman.webviewup.lib.util.VersionUtils;
 
 import java.io.File;
 import java.util.Arrays;
@@ -95,13 +92,13 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "com.huawei.webview",
                         "14.0.0.331",
                         "https://mirror.ghproxy.com/https://raw.githubusercontent.com/JonaNorman/ShareFile/main/com.huawei.webview_14.0.0.331_arm64-v8a_armeabi-v7a.zip",
-                        "网络"),
-                //https://mirrors.aliyun.com/android.googlesource.com/external/chromium-webview/prebuilt/arm64/
-                new UpgradeInfo(
-                        "com.android.webview",
-                        "109.0.5414.123",
-                        "",
-                        "安装包")
+                        "网络")
+                // https://mirrors.aliyun.com/android.googlesource.com/external/chromium-webview/prebuilt/arm64/
+//                new UpgradeInfo(
+//                        "com.android.webview",
+//                        "109.0.5414.123",
+//                        "",
+//                        "安装包")
         ));
 
         UPGRADE_PACKAGE_MAP.put("x86", Arrays.asList(
@@ -113,6 +110,11 @@ public class MainActivity extends Activity implements UpgradeCallback {
                 new UpgradeInfo("com.google.android.webview",
                         "131.0.6778.105",
                         "com.google.android.webview_131.0.6778.105-677810506_minAPI26_maxAPI28(x86)(nodpi)_apkmirror.com.apk",
+                        "内置"),
+                new UpgradeInfo(
+                        "com.android.webview",
+                        "109.5.5414.123",
+                        "x86_64/com.android.webview.apk",
                         "内置")
         ));
         UPGRADE_PACKAGE_MAP.put("x86_64", Arrays.asList(
@@ -127,10 +129,11 @@ public class MainActivity extends Activity implements UpgradeCallback {
                         "108.0.5359.156",
                         "",
                         "安装包"),
+                // https://mirrors.aliyun.com/android.googlesource.com/external/chromium-webview/prebuilt/x86_64/
                 new UpgradeInfo(
                         "com.android.webview",
                         "109.5.5414.123",
-                        "webview-x86.apk",
+                        "x86_64/com.android.webview.apk",
                         "内置")
         ));
 
@@ -230,8 +233,8 @@ public class MainActivity extends Activity implements UpgradeCallback {
                     Toast.makeText(getApplicationContext(), "webView is already upgrade success,not support dynamic switch", Toast.LENGTH_LONG).show();
                 } else {
                     UpgradeInfo upgradeInfo = upgradeInfoList.get(which);
-                    String  systemWebViewPackageName = WebViewUpgrade.getSystemWebViewPackageName();
-//                    if (systemWebViewPackageName != null &&systemWebViewPackageName.equals(upgradeInfo.packageName)
+                    String systemWebViewPackageName = WebViewUpgrade.getSystemWebViewPackageName();
+//                    if (systemWebViewPackageName != null && systemWebViewPackageName.equals(upgradeInfo.packageName)
 //                            && VersionUtils.compareVersion( WebViewUpgrade.getSystemWebViewPackageVersion(),upgradeInfo.versionName) >= 0) {
 //                        Toast.makeText(getApplicationContext(), "system webView is larger than the one to be upgraded, so there is no need to upgrade", Toast.LENGTH_LONG).show();
 //                        return;
@@ -402,7 +405,6 @@ public class MainActivity extends Activity implements UpgradeCallback {
         String title;
         String url;
         String packageName;
-
         String versionName;
         String extraInfo;
     }

--- a/core/src/main/java/com/norman/webviewup/lib/hook/PackageManagerServiceHook.java
+++ b/core/src/main/java/com/norman/webviewup/lib/hook/PackageManagerServiceHook.java
@@ -73,20 +73,19 @@ public class PackageManagerServiceHook extends BinderHook {
         @SuppressLint("LongLogTag")
         @Override
         protected ServiceInfo getServiceInfo(ComponentName componentName, long flags, int userId) {
-            Log.i(TAG, "【getServiceInfo】");
             if (!TextUtils.equals(webViewPackageName, componentName.getPackageName())) {
                 return (ServiceInfo) invoke();
             }
             Log.i(TAG, "getServiceInfo: " + componentName.getClassName());
-            if (!SANDBOXED_SERVICES_NAME.equals(componentName.getClassName())) {
-                return (ServiceInfo) invoke();
-            }
-            // Skip the sandboxed service check, 返回任意已存在的ServiceInfo跳过检查
+            // Skip service check, 返回已存在的ServiceInfo跳过检查
             PackageInfo packageInfo = getPackageInfo(componentName.getPackageName(), PackageManager.GET_SERVICES);
             if (packageInfo != null && packageInfo.services != null) {
-                ServiceInfo serviceInfo = packageInfo.services[0];
-                Log.i(TAG, "Skip the sandboxed service check, fake: " + serviceInfo.name);
-                return serviceInfo;
+                for (ServiceInfo serviceInfo : packageInfo.services) {
+                    if (serviceInfo.name.equals(componentName.getClassName())) {
+                        Log.i(TAG, "Skip service check, fake: " + serviceInfo.name);
+                        return serviceInfo;
+                    }
+                }
             }
             return (ServiceInfo) invoke();
         }

--- a/core/src/main/java/com/norman/webviewup/lib/service/proxy/PackageManagerProxy.java
+++ b/core/src/main/java/com/norman/webviewup/lib/service/proxy/PackageManagerProxy.java
@@ -2,6 +2,7 @@ package com.norman.webviewup.lib.service.proxy;
 
 import android.content.ComponentName;
 import android.content.pm.PackageInfo;
+import android.content.pm.ServiceInfo;
 
 import com.norman.webviewup.lib.reflect.RuntimeProxy;
 import com.norman.webviewup.lib.reflect.annotation.ClassName;
@@ -15,6 +16,8 @@ public abstract class PackageManagerProxy extends RuntimeProxy {
         super();
     }
 
+    @Method("getServiceInfo")
+    protected abstract ServiceInfo getServiceInfo(ComponentName componentName, long flags, int userId);
 
     @Method("getPackageInfo")
     protected abstract PackageInfo getPackageInfo(String packageName, long flags, int userId);

--- a/core/src/main/java/com/norman/webviewup/lib/source/UpgradePackageSource.java
+++ b/core/src/main/java/com/norman/webviewup/lib/source/UpgradePackageSource.java
@@ -26,6 +26,7 @@ public class UpgradePackageSource extends UpgradeSource {
     protected void onPrepare(Object params) {
         try {
             int flags = params instanceof Integer ? (int) params : 0;
+            flags |= PackageManager.GET_META_DATA;
             packageInfo = getContext().getPackageManager().getPackageInfo(packageName, flags);
             if (packageInfo == null) {
                 throw new PackageManager.NameNotFoundException("Package " + packageName + " doesn't exist");


### PR DESCRIPTION
引入[SkipSelfStartManager](https://github.com/HLQ-Struggle/SkipSelfStartManager)的跳转自启动管理界面，优化跳转的目标和提示

修复[issues/32](https://github.com/JonaNorman/WebViewUpgrade/issues/32)提出的问题，其中的备注需要留意一下。

增加方法跳过安卓15对未安装app的service是否存在的检查，解决高版本内置更新报错

添加hasWebViewLibrary判断已经选择的Webview是否是合法的Webview实现

另外，我在虚拟机测试安装org.bromite.webview是正常不需要自启动权限，应该是只有国内系统会这样。

# 原理
最开始在我的小米手机上发现chrome必须在后台运行，才能正常使用chrome作为webview启动。然后想后台启用包名/org.chromium.android_webview.devui.MainActivity来直接启动app发现不太行，因为我不会后台启动activity。

后面发现可以[用bindService来直接判断服务是否已经启动](https://github.com/JonaNorman/WebViewUpgrade/commit/d0915196a282cecbcee148af9cdb8aeaafe2162b#diff-06a081cb809d6cf16aaf95323b00095d84dc8784d7192e3d3f9e215ea51bd3c4R237)（后续等大佬优化），如果抛出错误
java.lang.SecurityException: BIND_EXTERNAL_SERVICE required for ComponentInfo{包名/org.chromium.content.app.SandboxedProcessService0}就证明服务已经启动了。

# 目前测试结果:
## 安卓15虚拟机
可以直接运行已经安装的org.bromite.webview
## 安卓15的小米
可以跟据弹窗指示，运行com.android.chrome，com.android.webview，com.huawei.webview，org.bromite.webview。

![86ac0d7b1b79e99b74130dce7ada82b9](https://github.com/user-attachments/assets/d82e85bf-ef72-41a0-9e12-4d663957e6f9)

![5849196477fd0eff1bb0112afa107761_720](https://github.com/user-attachments/assets/65cf1086-c5c8-4eb3-b66c-75d6bf144c45)
