### PR TITLE
refactor: 重构内核选择对话框及优化主活动布局

### DIFF
--- a/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
+++ b/app/src/main/java/com/norman/webviewup/demo/MainActivity.java
@@ -4,7 +4,6 @@ import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.pm.PackageManager;
-import android.graphics.drawable.ColorDrawable;
 import android.graphics.Typeface;
 import android.os.Bundle;
 import android.text.SpannableStringBuilder;
@@ -15,10 +14,9 @@ import android.text.style.StyleSpan;
 import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.ArrayAdapter;
 import android.widget.Button;
-import android.widget.ListView;
+import android.widget.ImageView;
+import android.widget.LinearLayout;
 import android.widget.ProgressBar;
 import android.widget.TextView;
 import android.widget.Toast;
@@ -36,7 +34,9 @@ import com.norman.webviewup.lib.source.UpgradeSource;
 import com.norman.webviewup.lib.util.RestartUtil;
 
 import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 
 public class MainActivity extends Activity implements UpgradeCallback {
 
@@ -58,6 +58,8 @@ public class MainActivity extends Activity implements UpgradeCallback {
 
     @Nullable
     DemoUpgradeChoice selectUpgradeChoice;
+
+    private AlertDialog currentKernelPickerDialog;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -190,72 +192,178 @@ public class MainActivity extends Activity implements UpgradeCallback {
             return;
         }
 
-        final List<DemoUpgradeChoice> list = new ArrayList<>(choices);
         AlertDialog.Builder builder = new AlertDialog.Builder(this);
         builder.setTitle(R.string.wv_dialog_title);
-        ArrayAdapter<DemoUpgradeChoice> adapter = new ArrayAdapter<DemoUpgradeChoice>(
-                this, 0, list) {
-            @NonNull
-            @Override
-            public View getView(int position, @Nullable View convertView, @NonNull ViewGroup parent) {
-                View row = convertView;
-                if (row == null) {
-                    row = LayoutInflater.from(getContext()).inflate(
-                            R.layout.dialog_item_webview_choice, parent, false);
+
+        View dialogView = LayoutInflater.from(this).inflate(R.layout.dialog_kernel_picker, null);
+        LinearLayout container = dialogView.findViewById(R.id.kernelListContainer);
+
+        List<DemoUpgradeChoice> list = new ArrayList<>(choices);
+
+        DemoUpgradeChoice installedChrome = null;
+        Map<String, List<DemoUpgradeChoice>> vendorGroups = new LinkedHashMap<>();
+
+        for (DemoUpgradeChoice choice : list) {
+            if (choice.sourceKind == DemoUpgradeChoice.SourceKind.INSTALLED_PACKAGE) {
+                installedChrome = choice;
+            } else {
+                String vendorKey = extractVendorFromLine(choice.lineVendorArch);
+                if (!vendorGroups.containsKey(vendorKey)) {
+                    vendorGroups.put(vendorKey, new ArrayList<>());
                 }
-                DemoUpgradeChoice c = list.get(position);
-                TextView lineVendorArch = row.findViewById(R.id.wv_choice_line_vendor_arch);
-                TextView lineStatusVer = row.findViewById(R.id.wv_choice_line_status_version);
-                lineVendorArch.setText(c.lineVendorArch);
-                lineStatusVer.setText(buildStatusVersionLine(getContext(), c));
-                return row;
+                vendorGroups.get(vendorKey).add(choice);
             }
-        };
-        builder.setAdapter(adapter, new DialogInterface.OnClickListener() {
+        }
+
+        if (installedChrome != null) {
+            View chromeView = createInstalledChromeView(installedChrome, restartAfterSelection);
+            container.addView(chromeView);
+
+            View divider = new View(this);
+            divider.setLayoutParams(new LinearLayout.LayoutParams(
+                    LinearLayout.LayoutParams.MATCH_PARENT, 2));
+            divider.setBackgroundColor(ContextCompat.getColor(this, R.color.wv_divider));
+            divider.setPadding(0, 16, 0, 16);
+            container.addView(divider);
+        }
+
+        for (Map.Entry<String, List<DemoUpgradeChoice>> entry : vendorGroups.entrySet()) {
+            String vendorName = entry.getKey();
+            List<DemoUpgradeChoice> vendorChoices = entry.getValue();
+
+            View groupView = createVendorGroupView(vendorName, vendorChoices, restartAfterSelection);
+            container.addView(groupView);
+        }
+
+        builder.setView(dialogView);
+        currentKernelPickerDialog = builder.create();
+        currentKernelPickerDialog.show();
+    }
+
+    private String extractVendorFromLine(String lineVendorArch) {
+        if (lineVendorArch.contains(" · ")) {
+            return lineVendorArch.split(" · ")[0];
+        }
+        return lineVendorArch;
+    }
+
+    private View createInstalledChromeView(final DemoUpgradeChoice chrome,
+                                           final boolean restartAfterSelection) {
+        View view = LayoutInflater.from(this).inflate(R.layout.dialog_item_webview_choice, null);
+
+        TextView lineVendorArch = view.findViewById(R.id.wv_choice_line_vendor_arch);
+        TextView lineStatusVer = view.findViewById(R.id.wv_choice_line_status_version);
+
+        lineVendorArch.setText(chrome.lineVendorArch);
+        lineStatusVer.setText(buildStatusVersionLine(this, chrome));
+
+        view.setOnClickListener(new View.OnClickListener() {
             @Override
-            public void onClick(DialogInterface dialog, int which) {
-                dialog.dismiss();
-                if (WebViewUpgrade.isProcessing()) {
-                    Toast.makeText(getApplicationContext(), R.string.wv_upgrade_in_progress, Toast.LENGTH_LONG).show();
-                    return;
-                }
-                DemoUpgradeChoice choice = list.get(which);
-                UpgradeSource upgradeSource = choice.toUpgradeSource(MainActivity.this);
-                if (upgradeSource == null) {
-                    Toast.makeText(getApplicationContext(), R.string.wv_invalid_upgrade_source, Toast.LENGTH_SHORT).show();
-                    return;
-                }
-                if (restartAfterSelection) {
-                    selectUpgradeChoice = choice;
-                    PreferredWebViewStore.save(MainActivity.this, choice);
-                    RestartUtil.restart(getApplication(),
-                            new Runnable() {
-                                @Override
-                                public void run() {
-                                    DemoWebViewHolder.destroyHeldWebView();
-                                }
-                            });
-                    return;
-                }
-                if (WebViewUpgrade.isCompleted()) {
-                    Toast.makeText(getApplicationContext(), R.string.wv_upgrade_already_done, Toast.LENGTH_LONG).show();
-                    return;
-                }
-                selectUpgradeChoice = choice;
-                WebViewUpgrade.upgrade(upgradeSource);
-                updateUpgradeWebViewPackageInfo();
-                updateKernelPendingLine();
-                updateUpgradeWebViewStatus();
-                updateActionButtons();
+            public void onClick(View v) {
+                handleChoiceSelection(chrome, restartAfterSelection);
             }
         });
-        AlertDialog dialog = builder.create();
-        dialog.show();
-        ListView lv = dialog.getListView();
-        if (lv != null) {
-            lv.setDivider(new ColorDrawable(0x00000000));
-            lv.setDividerHeight(0);
+
+        view.setBackgroundResource(R.color.wv_chrome_highlight);
+
+        return view;
+    }
+
+    private View createVendorGroupView(final String vendorName,
+                                       final List<DemoUpgradeChoice> choices,
+                                       final boolean restartAfterSelection) {
+        View view = LayoutInflater.from(this).inflate(R.layout.item_vendor_group, null);
+
+        TextView vendorNameText = view.findViewById(R.id.vendorName);
+        TextView versionCountText = view.findViewById(R.id.versionCount);
+        ImageView expandIcon = view.findViewById(R.id.expandIcon);
+        final LinearLayout contentLayout = view.findViewById(R.id.vendorContent);
+        View header = view.findViewById(R.id.vendorHeader);
+
+        vendorNameText.setText(vendorName);
+        versionCountText.setText("(" + choices.size() + ")");
+
+        final boolean[] isExpanded = {false};
+
+        for (DemoUpgradeChoice choice : choices) {
+            View itemView = LayoutInflater.from(this)
+                    .inflate(R.layout.dialog_item_webview_choice, contentLayout, false);
+
+            TextView lineVendorArch = itemView.findViewById(R.id.wv_choice_line_vendor_arch);
+            TextView lineStatusVer = itemView.findViewById(R.id.wv_choice_line_status_version);
+
+            lineVendorArch.setText(choice.lineVendorArch);
+            lineStatusVer.setText(buildStatusVersionLine(this, choice));
+
+            itemView.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    handleChoiceSelection(choice, restartAfterSelection);
+                }
+            });
+
+            contentLayout.addView(itemView);
         }
+
+        header.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                isExpanded[0] = !isExpanded[0];
+
+                if (isExpanded[0]) {
+                    contentLayout.setVisibility(View.VISIBLE);
+                    expandIcon.setImageResource(android.R.drawable.arrow_up_float);
+                } else {
+                    contentLayout.setVisibility(View.GONE);
+                    expandIcon.setImageResource(android.R.drawable.arrow_down_float);
+                }
+            }
+        });
+
+        return view;
+    }
+
+    private void handleChoiceSelection(DemoUpgradeChoice choice, boolean restartAfterSelection) {
+        if (WebViewUpgrade.isProcessing()) {
+            Toast.makeText(getApplicationContext(), R.string.wv_upgrade_in_progress, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        UpgradeSource upgradeSource = choice.toUpgradeSource(MainActivity.this);
+        if (upgradeSource == null) {
+            Toast.makeText(getApplicationContext(), R.string.wv_invalid_upgrade_source, Toast.LENGTH_SHORT).show();
+            return;
+        }
+
+        if (currentKernelPickerDialog != null && currentKernelPickerDialog.isShowing()) {
+            currentKernelPickerDialog.dismiss();
+            currentKernelPickerDialog = null;
+        }
+
+        if (restartAfterSelection) {
+            selectUpgradeChoice = choice;
+            PreferredWebViewStore.save(MainActivity.this, choice);
+            RestartUtil.restart(getApplication(),
+                    new Runnable() {
+                        @Override
+                        public void run() {
+                            DemoWebViewHolder.destroyHeldWebView();
+                        }
+                    });
+            return;
+        }
+
+        if (WebViewUpgrade.isCompleted()) {
+            Toast.makeText(getApplicationContext(), R.string.wv_upgrade_already_done, Toast.LENGTH_LONG).show();
+            return;
+        }
+
+        selectUpgradeChoice = choice;
+        WebViewUpgrade.upgrade(upgradeSource);
+        updateUpgradeWebViewPackageInfo();
+        updateKernelPendingLine();
+        updateUpgradeWebViewStatus();
+        updateActionButtons();
     }
 
     @Override

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -130,15 +130,6 @@
                 tools:text="42%" />
         </LinearLayout>
 
-        <TextView
-            android:id="@+id/upgradeErrorTextView"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:layout_marginTop="10dp"
-            android:textColor="@color/wv_error_text"
-            android:textSize="13sp"
-            tools:text="Error detail" />
-
         <LinearLayout
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
@@ -174,5 +165,15 @@
                 android:layout_marginTop="8dp"
                 android:text="@string/wv_btn_restore" />
         </LinearLayout>
+
+        <TextView
+            android:id="@+id/upgradeErrorTextView"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="10dp"
+            android:textColor="@color/wv_error_text"
+            android:textSize="13sp"
+            tools:text="Error detail" />
+
     </LinearLayout>
 </ScrollView>

--- a/app/src/main/res/layout/dialog_kernel_picker.xml
+++ b/app/src/main/res/layout/dialog_kernel_picker.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <ScrollView
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:maxHeight="600dp">
+
+        <LinearLayout
+            android:id="@+id/kernelListContainer"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:orientation="vertical"
+            android:padding="8dp" />
+
+    </ScrollView>
+
+</LinearLayout>

--- a/app/src/main/res/layout/item_vendor_group.xml
+++ b/app/src/main/res/layout/item_vendor_group.xml
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:orientation="vertical">
+
+    <!-- 厂商标题（可点击展开/收起） -->
+    <LinearLayout
+        android:id="@+id/vendorHeader"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:background="?attr/selectableItemBackground"
+        android:clickable="true"
+        android:focusable="true"
+        android:gravity="center_vertical"
+        android:orientation="horizontal"
+        android:padding="12dp">
+
+        <ImageView
+            android:id="@+id/expandIcon"
+            android:layout_width="24dp"
+            android:layout_height="24dp"
+            android:src="@android:drawable/arrow_down_float"
+            android:contentDescription="@string/wv_expand_collapse" />
+
+        <TextView
+            android:id="@+id/vendorName"
+            android:layout_width="0dp"
+            android:layout_height="wrap_content"
+            android:layout_marginStart="8dp"
+            android:layout_weight="1"
+            android:textColor="@android:color/black"
+            android:textSize="16sp"
+            android:textStyle="bold" />
+
+        <TextView
+            android:id="@+id/versionCount"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginEnd="8dp"
+            android:textColor="@color/wv_text_secondary"
+            android:textSize="12sp" />
+
+    </LinearLayout>
+
+    <!-- 该厂商下的版本列表 -->
+    <LinearLayout
+        android:id="@+id/vendorContent"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:orientation="vertical"
+        android:visibility="gone"
+        android:paddingStart="44dp"
+        android:paddingEnd="8dp" />
+
+    <View
+        android:layout_width="match_parent"
+        android:layout_height="1dp"
+        android:layout_marginTop="4dp"
+        android:layout_marginBottom="4dp"
+        android:background="#E0E0E0" />
+
+</LinearLayout>

--- a/app/src/main/res/values-zh-rCN/strings.xml
+++ b/app/src/main/res/values-zh-rCN/strings.xml
@@ -17,6 +17,8 @@
     <string name="wv_status_prefetch">需 prefetch</string>
     <string name="wv_status_installed">已安装</string>
 
+    <string name="wv_expand_collapse">展开或收起</string>
+
     <string name="wv_vendor_unknown">未知</string>
     <string name="wv_vendor_android">Android</string>
     <string name="wv_vendor_google">Google</string>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -7,4 +7,6 @@
     <color name="wv_tone_prefetch">#C62828</color>
     <color name="wv_text_secondary">#757575</color>
     <color name="wv_error_text">#B00020</color>
+    <color name="wv_chrome_highlight">#E3F2FD</color>
+    <color name="wv_divider">#E0E0E0</color>
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -19,6 +19,8 @@
     <string name="wv_status_prefetch">Prefetch</string>
     <string name="wv_status_installed">Installed</string>
 
+    <string name="wv_expand_collapse">Expand or collapse</string>
+
     <string name="wv_vendor_unknown">Unknown</string>
     <string name="wv_vendor_android">Android</string>
     <string name="wv_vendor_google">Google</string>


### PR DESCRIPTION
## 变更类型
- [x] 重构（不改变功能的代码改进）

## 主要改动
1. **内核选择对话框重构** (698640c)
   - 优化对话框界面结构
   - 改进交互逻辑和视觉层次

2. **主活动布局优化** (49b53bb)
   - 重新排列升级错误文本视图
   - 改善布局结构和可维护性

## 测试
- 手动测试内核选择和升级功能
- 验证 UI 显示正常

## 影响范围
- 仅 UI 层重构，无业务逻辑变更
- 向下兼容，无破坏性改动

## 截图
<div style="display: flex; gap: 10px;">
  <img src="https://github.com/user-attachments/assets/b9790a47-7f3f-450f-84d8-f1805b6920c2" width="300" alt="内核选择对话框界面" />
  <img src="https://github.com/user-attachments/assets/512abd6b-9313-4fd4-8eac-2fa612fede5e" width="300" alt="主活动布局优化" />
</div>