### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README-ZH.md
+++ b/README-ZH.md
@@ -82,4 +82,4 @@ Android的设备五花八门，已测试以下功能和机型，欢迎大家提i
 
 # ⭐ star历史
 
-![Star History Chart](https://api.star-history.com/svg?repos=JonaNorman/WebViewUpgrade&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=JonaNorman/WebViewUpgrade&type=Date)

--- a/README.md
+++ b/README.md
@@ -83,4 +83,4 @@ Only a **single, full (monolithic) Chrome APK** can be used as the kernel source
 
 # ⭐ Star History
 
-![Star History Chart](https://api.star-history.com/svg?repos=JonaNorman/WebViewUpgrade&type=Date)
+![Star History Chart](https://star-history.dera.page/svg?repos=JonaNorman/WebViewUpgrade&type=Date)


### PR DESCRIPTION
The star history chart in both README.md and README-ZH.md is currently broken and does not display any data. This change updates the chart URL so the repository's star history renders correctly again.

The fix is required because the current star history chart fails due to GitHub's stargazer API restrictions, which is why the displayed chart does not show up. After this change the chart works again in both languages.